### PR TITLE
Only show "File created." message if  using --verbose flag

### DIFF
--- a/tasks/po2json.js
+++ b/tasks/po2json.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
         }
 
         grunt.file.write(dest, contents);
-        grunt.log.writeln('File "' + dest + '" created.');
+        grunt.verbose.writeln('File "' + dest + '" created.');
       });
     });
 


### PR DESCRIPTION
Not as pretty as @vladikoff's https://github.com/rockykitamura/grunt-po2json/commit/aa9fe9b21a9092bee7e51299cf439bb14fc73b0c patch, but should silence our fxa-content-server Travis logs by about 210 lines.